### PR TITLE
Add node v18 for 10.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - 'master'
   schedule:
     - cron: '15 4 1 * *'
   workflow_dispatch:
@@ -32,7 +26,7 @@ jobs:
       - uses: docker/setup-buildx-action@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '18'
 
       - name: Build Meta
         id: meta

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM docker.io/bitnami/minideb:buster
 LABEL maintainer "Dan Gibbs <dev@dangibbs.co.uk>"
 
+ARG lighthouse_version=latest
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
@@ -11,14 +12,16 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
         chromium-sandbox \
         ca-certificates \
         curl \
+        git \
         fonts-freefont-ttf \
         fonts-liberation \
         jq; \
-    curl -L https://deb.nodesource.com/setup_14.x | bash -; \
+    curl -L https://deb.nodesource.com/setup_18.x | bash -; \
     cat /etc/apt/sources.list.d/nodesource.list; \
     apt-get install -y --no-install-recommends \
         nodejs; \
-    npm i -g --production lighthouse@latest; \
+    npm update -g npm; \
+    npm i -g --omit=dev lighthouse@${lighthouse_version}; \
     apt-get purge -y curl; \
     apt-get autoremove -y; \
     apt-get clean && apt-get autoclean -y && \


### PR DESCRIPTION
- Use node v18
- Support installing specific lighthouse version via build argument
- Add git dependency
- Remove workflow build on push and pull requests